### PR TITLE
Optimize inside_points with Numpy magic

### DIFF
--- a/icosphere.py
+++ b/icosphere.py
@@ -240,7 +240,8 @@ def inside_points(vAB, vAC):
     """
 
     out = []
-    for i in range(1, vAB.shape[0]):
+    u = vAB.shape[0]
+    for i in range(0 if u == 1 else 1, u):
         # Linearly interpolate between vABi and vACi in `i + 1` (`j`) steps,
         # not including the endpoints.
         # This could be written as

--- a/icosphere.py
+++ b/icosphere.py
@@ -226,8 +226,8 @@ def vertex_ordering(nu):
     return(np.array(o))
 
 
-def inside_points(vAB,vAC):
-    '''  
+def inside_points(vAB, vAC):
+    """
     Returns coordinates of the inside                 .
     (on-face) vertices (marked by star)              / \
     for subdivision of the face ABC when         vAB0---vAC0
@@ -236,13 +236,24 @@ def inside_points(vAB,vAC):
                                                  / \ / \ / \
                                              vAB2---*---*---vAC2
                                                / \ / \ / \ / \
-                                              .---.---.---.---. 
-    '''
-   
-    v = []
-    for i in range(1,vAB.shape[0]):
-        w = np.arange(1,i+1)/(i+1)
-        for k in range(i):
-            v.append(w[-1-k]*vAB[i,:] + w[k]*vAC[i,:])
-    
-    return(np.array(v).reshape(-1,3)) # reshape needed for empty return
+                                              .---.---.---.---.
+    """
+
+    out = []
+    for i in range(1, vAB.shape[0]):
+        # Linearly interpolate between vABi and vACi in `i + 1` (`j`) steps,
+        # not including the endpoints.
+        # This could be written as
+        #   vABi = vAB[i, :]
+        #   vACi = vAC[i, :]
+        #   interp_multipliers = np.arange(1, j) / j
+        #   res = np.outer(interp_multipliers, vACi) + np.outer(1 - interp_multipliers, vABi)
+        # but that will involve some extra work on `np.outer`'s part that we can
+        # do ourselves since we know the shapes we're working with.
+        j = i + 1
+        interp_multipliers = (np.arange(1, j) / j)[:, None]
+        out.append(
+            np.multiply(interp_multipliers, vAC[i, None]) +
+            np.multiply(1 - interp_multipliers, vAB[i, None])
+        )
+    return np.concatenate(out)

--- a/test_icosphere.py
+++ b/test_icosphere.py
@@ -1,0 +1,11 @@
+import pytest
+
+import icosphere
+
+
+@pytest.mark.parametrize("nu", [1, 2, 3, 5, 10])
+def test_icosphere(nu):
+    sv, sf = icosphere.icosphere(nu)
+    # Just a smoke test for now...
+    assert sv.shape
+    assert sf.shape


### PR DESCRIPTION
I profiled the library a bit and noticed `inside_points()` was by far the hottest function.

I wrote a small verification/benchmark script that tests that the output for `icosphere(nu)` (with `nu` from 5 to 200) is this is the same as on be65c259ed09749c02b1d625d774f7b416480205.

The approximate speedup on my machine is 5-8x (and I'm not a Numpy magician by any means, so there could be ways to make this faster still):

```
nu = 5 / ratio: 0.97 (this 0.01s / baseline 0.01s)
nu = 10 / ratio: 0.71 (this 0.01s / baseline 0.02s)
nu = 15 / ratio: 0.55 (this 0.02s / baseline 0.03s)
nu = 20 / ratio: 0.39 (this 0.02s / baseline 0.05s)
nu = 25 / ratio: 0.49 (this 0.04s / baseline 0.07s)
nu = 30 / ratio: 0.34 (this 0.03s / baseline 0.10s)
nu = 35 / ratio: 0.29 (this 0.04s / baseline 0.13s)
nu = 40 / ratio: 0.24 (this 0.04s / baseline 0.18s)
nu = 45 / ratio: 0.22 (this 0.05s / baseline 0.22s)
nu = 50 / ratio: 0.20 (this 0.05s / baseline 0.27s)
nu = 55 / ratio: 0.20 (this 0.06s / baseline 0.30s)
nu = 60 / ratio: 0.19 (this 0.07s / baseline 0.36s)
nu = 65 / ratio: 0.17 (this 0.07s / baseline 0.43s)
nu = 70 / ratio: 0.16 (this 0.08s / baseline 0.50s)
[...]
nu = 155 / ratio: 0.13 (this 0.33s / baseline 2.55s)
nu = 160 / ratio: 0.10 (this 0.29s / baseline 2.88s)
nu = 165 / ratio: 0.11 (this 0.32s / baseline 2.94s)
nu = 170 / ratio: 0.12 (this 0.36s / baseline 3.08s)
nu = 175 / ratio: 0.11 (this 0.34s / baseline 3.18s)
nu = 180 / ratio: 0.12 (this 0.41s / baseline 3.36s)
nu = 185 / ratio: 0.11 (this 0.39s / baseline 3.67s)
nu = 190 / ratio: 0.10 (this 0.40s / baseline 3.85s)
nu = 195 / ratio: 0.11 (this 0.45s / baseline 4.07s)
nu = 200 / ratio: 0.11 (this 0.45s / baseline 4.30s)
nu = 205 / ratio: 0.10 (this 0.45s / baseline 4.67s)
nu = 210 / ratio: 0.10 (this 0.48s / baseline 5.01s)
nu = 215 / ratio: 0.11 (this 0.51s / baseline 4.82s)
```